### PR TITLE
Attempt to make the Ansible filter work on Python 3

### DIFF
--- a/ansible/filter.py
+++ b/ansible/filter.py
@@ -6,6 +6,12 @@
 import ansible
 import subprocess
 
+try:
+    # ansible-2.2 and later
+    from ansible.module_utils._text import to_native
+except:
+    from ansible.utils.unicode import to_native
+
 def gpg_d(file):
     try:
         output = subprocess.check_output(
@@ -16,7 +22,7 @@ def gpg_d(file):
     if output == "":
         raise ansible.errors.AnsibleFilterError(
             'gpg --decrypt '+file+' produced no output')
-    return output
+    return to_native(output)
 
 class FilterModule(object):
     def filters(self):


### PR DESCRIPTION
Ansible now aims to support Python3 on both the controler and
in modules, and MacOS Homebrew (at least for me) installs Ansible
running under Python3.

The gpg_d filter doesn't then seem to work, I think because
it is returning a byte string rather than a native string. This patch
aims to fix this by reference to code in action.py and
https://docs.ansible.com/ansible/latest/dev_guide/developing_python_3.html

It's been minimally tested, but does seem to fix the problem for Python3
under MacOS. I don't know if it breaks things under Python2.