### PR TITLE
Remove link to out-of-date gitlab.cam repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ You can clone or browse the repository from:
 
 * <https://dotat.at/cgi/git/regpg.git>
 * <https://github.com/fanf2/regpg.git>
-* <https://gitlab.developers.cam.ac.uk/fanf2/regpg>
-
 
 Acknowledgments
 ---------------


### PR DESCRIPTION
While gitlab.developers.cam.ac.uk/fanf2/regpg still exists, it's out of date, so stop referring to it in the docs.